### PR TITLE
moved transaction version inside the tx object that gets hashed

### DIFF
--- a/bigchaindb/util.py
+++ b/bigchaindb/util.py
@@ -169,8 +169,8 @@ def create_tx(current_owners, new_owners, inputs, operation, payload=None):
     Reference:
         {
             "id": "<sha3 hash>",
-            "version": "transaction version number",
             "transaction": {
+                "version": "transaction version number",
                 "fulfillments": [
                         {
                             "current_owners": ["list of <pub-keys>"],
@@ -278,6 +278,7 @@ def create_tx(current_owners, new_owners, inputs, operation, payload=None):
             })
 
     tx = {
+        'version': 1,
         'fulfillments': fulfillments,
         'conditions': conditions,
         'operation': operation,
@@ -291,7 +292,6 @@ def create_tx(current_owners, new_owners, inputs, operation, payload=None):
     # create the transaction
     transaction = {
         'id': tx_hash,
-        'version': 1,
         'transaction': tx
     }
 

--- a/docs/source/topic-guides/models.md
+++ b/docs/source/topic-guides/models.md
@@ -58,8 +58,8 @@ Assets can be mutable (changeable) or immutable. To change a mutable asset, you 
 ```json
 {
     "id": "<hash of transaction, excluding signatures (see explanation)>",
-    "version": "<version number of the transaction model>",
     "transaction": {
+        "version": "<version number of the transaction model>",
         "fulfillments": ["<list of fulfillments>"],
         "conditions": ["<list of conditions>"],
         "operation": "<string>",
@@ -75,8 +75,8 @@ Assets can be mutable (changeable) or immutable. To change a mutable asset, you 
 Here's some explanation of the contents of a transaction:
 
 - `id`: The hash of everything inside the serialized `transaction` body (i.e. `fulfillments`, `conditions`, `operation`, `timestamp` and `data`; see below), with one wrinkle: for each fulfillment in `fulfillments`, `fulfillment` is set to `null`. The `id` is also the database primary key.
-- `version`: Version number of the transaction model, so that software can support different transaction models.
 - `transaction`:
+    - `version`: Version number of the transaction model, so that software can support different transaction models.
     - `fulfillments`: List of fulfillments. Each _fulfillment_ contains a pointer to an unspent asset
     and a _crypto fulfillment_ that satisfies a spending condition set on the unspent asset. A _fulfillment_
     is usually a signature proving the ownership of the asset.


### PR DESCRIPTION
As per issue 341 at https://github.com/bigchaindb/bigchaindb/issues/341

moved the transaction version (currently fixed to 1.0) from the outer
"transaction" object to the inside part, where it will get hashed
together with the rest of the transaction.

updated docs accordingly.
