### PR TITLE
moved version to be inside the transaction

### DIFF
--- a/bigchaindb/util.py
+++ b/bigchaindb/util.py
@@ -479,7 +479,7 @@ def get_fulfillment_message(transaction, fulfillment, serialized=False):
         'operation': transaction['transaction']['operation'],
         'timestamp': transaction['transaction']['timestamp'],
         'data': transaction['transaction']['data'],
-        'version': transaction['version'],
+        'version': transaction['transaction']['version'],
         'id': transaction['id']
     }
     # and the condition which needs to be retrieved from the output of a previous transaction

--- a/tests/db/test_bigchain_api.py
+++ b/tests/db/test_bigchain_api.py
@@ -38,8 +38,8 @@ class TestBigchainApi(object):
     def test_create_transaction_create(self, b, user_sk):
         tx = b.create_transaction(b.me, user_sk, None, 'CREATE')
 
-        assert sorted(tx) == ['id', 'transaction', 'version']
-        assert sorted(tx['transaction']) == ['conditions', 'data', 'fulfillments', 'operation', 'timestamp']
+        assert sorted(tx) == ['id', 'transaction']
+        assert sorted(tx['transaction']) == ['conditions', 'data', 'fulfillments', 'operation', 'timestamp', 'version']
 
     def test_create_transaction_with_unsupported_payload_raises(self, b):
         with pytest.raises(TypeError):
@@ -79,8 +79,8 @@ class TestBigchainApi(object):
 
         tx = b.create_transaction(user_vk, b.me, input_tx, 'TRANSFER')
 
-        assert sorted(tx) == ['id', 'transaction', 'version']
-        assert sorted(tx['transaction']) == ['conditions', 'data', 'fulfillments', 'operation', 'timestamp']
+        assert sorted(tx) == ['id', 'transaction']
+        assert sorted(tx['transaction']) == ['conditions', 'data', 'fulfillments', 'operation', 'timestamp', 'version']
 
         tx_signed = b.sign_transaction(tx, user_sk)
 
@@ -1169,7 +1169,7 @@ class TestFulfillmentMessage(object):
         assert fulfillment_message['fulfillment']['input'] == original_fulfillment['input']
         assert fulfillment_message['operation'] == tx['transaction']['operation']
         assert fulfillment_message['timestamp'] == tx['transaction']['timestamp']
-        assert fulfillment_message['version'] == tx['version']
+        assert fulfillment_message['version'] == tx['transaction']['version']
 
     @pytest.mark.usefixtures('inputs')
     def test_fulfillment_message_transfer(self, b, user_vk):
@@ -1192,7 +1192,7 @@ class TestFulfillmentMessage(object):
         assert fulfillment_message['fulfillment']['input'] == original_fulfillment['input']
         assert fulfillment_message['operation'] == tx['transaction']['operation']
         assert fulfillment_message['timestamp'] == tx['transaction']['timestamp']
-        assert fulfillment_message['version'] == tx['version']
+        assert fulfillment_message['version'] == tx['transaction']['version']
 
     def test_fulfillment_message_multiple_current_owners_multiple_new_owners_multiple_inputs(self, b, user_vk):
         # create a new users
@@ -1230,7 +1230,7 @@ class TestFulfillmentMessage(object):
             assert fulfillment_message['fulfillment']['input'] == original_fulfillment['input']
             assert fulfillment_message['operation'] == tx['transaction']['operation']
             assert fulfillment_message['timestamp'] == tx['transaction']['timestamp']
-            assert fulfillment_message['version'] == tx['version']
+            assert fulfillment_message['version'] == tx['transaction']['version']
 
 
 class TestTransactionMalleability(object):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -151,7 +151,7 @@ def test_create_tx_with_empty_inputs():
     tx = create_tx(None, None, [], None)
     assert 'id' in tx
     assert 'transaction' in tx
-    assert 'version' in tx
+    assert 'version' in tx['transaction']
     assert 'fulfillments' in tx['transaction']
     assert 'conditions' in tx['transaction']
     assert 'operation' in tx['transaction']


### PR DESCRIPTION
As per #341
moved the transaction version (currently fixed to 1) from the outer
"transaction" object to the inside part, where it will get hashed
together with the rest of the transaction.
updated docs accordingly.
Note that this might kill backwards compatibility.
